### PR TITLE
Zstd

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "extern/pybind11"]
 	path = extern/pybind11
 	url = https://github.com/pybind/pybind11.git
+[submodule "extern/zstd"]
+	path = extern/zstd
+	url = https://github.com/facebook/zstd.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(TROY_MEMORY_POOL "Use memory pool" ON)
 option(TROY_MEMORY_POOL_UNSAFE "Use unsafe memory pool" OFF)
 option(TROY_PYBIND "Build python encapsulation with Pybind11" ON)
 option(TROY_EXAMPLES "Build examples" OFF)
+option(TROY_ZSTD "Use Zstandard for compression" ON)
 
 if (TROY_MEMORY_POOL_UNSAFE)
   # if TROY_MEMORY_POOL_UNSAFE is enabled, TROY_MEMORY_POOL must be enabled
@@ -49,6 +50,14 @@ if (TROY_MEMORY_POOL_UNSAFE)
     message(WARNING "Setting TROY_MEMORY_POOL to ON.")
     set(TROY_MEMORY_POOL ON)
   endif()
+endif()
+
+if(TROY_ZSTD)
+  # Since zstd have warnings about "-Wmaybe-unitialized", we disable this warning first before including
+  # the zstd library
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
+  add_subdirectory(extern/zstd/build/cmake)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmaybe-uninitialized")
 endif()
 
 find_package(Threads REQUIRED)

--- a/examples/7_serialization.cu
+++ b/examples/7_serialization.cu
@@ -40,10 +40,10 @@ void example_serialization()
 
     // Saving the public key requires the knowledge of the HE context.
     public_key_with_seed.save(pk_stream1, context);
-    std::cout << "PublicKey with seed size = " << pk_stream1.str().size() << std::endl;
+    std::cout << "PublicKey with seed size                = " << pk_stream1.str().size() << " bytes" << std::endl;
     stringstream pk_stream2;
     public_key_without_seed.save(pk_stream2, context);
-    std::cout << "PublicKey without seed size = " << pk_stream2.str().size() << std::endl;
+    std::cout << "PublicKey without seed size             = " << pk_stream2.str().size() << " bytes" << std::endl;
     
     // To deserialize, the HE context is also required.
     // If a public key with a seed is loaded, the seed is expanded automatically when
@@ -72,7 +72,7 @@ void example_serialization()
 
     stringstream ct_stream1;
     encrypted.save(ct_stream1, context);
-    std::cout << "Ciphertext asymmetrical size = " << ct_stream1.str().size() << std::endl;
+    std::cout << "Ciphertext asymmetrical size            = " << ct_stream1.str().size() << " bytes" << std::endl;
 
     // Symmetric encryption
     SecretKey secret_key = keygen.secret_key();
@@ -84,7 +84,7 @@ void example_serialization()
     Ciphertext encrypted_symmetric = encryptor.encrypt_symmetric_new(plain, true);
     stringstream ct_stream2;
     encrypted_symmetric.save(ct_stream2, context);
-    std::cout << "Ciphertext with seed size = " << ct_stream2.str().size() << std::endl;
+    std::cout << "Ciphertext with seed size               = " << ct_stream2.str().size() << " bytes" << std::endl;
 
     // To deserialize, the HE context is also required.
     Ciphertext deserialized_ct;
@@ -95,11 +95,27 @@ void example_serialization()
     Ciphertext encrypted_symmetric_no_seed = encryptor.encrypt_symmetric_new(plain, false);
     stringstream ct_stream3;
     encrypted_symmetric_no_seed.save(ct_stream3, context);
-    std::cout << "Ciphertext without seed size = " << ct_stream3.str().size() << std::endl;
+    std::cout << "Ciphertext without seed size            = " << ct_stream3.str().size() << " bytes" << std::endl;
     encrypted_symmetric.expand_seed(context);
     stringstream ct_stream4;
     encrypted_symmetric.save(ct_stream4, context);
-    std::cout << "Ciphertext expanded size = " << ct_stream4.str().size() << std::endl;
+    std::cout << "Ciphertext expanded size                = " << ct_stream4.str().size() << " bytes" << std::endl;
+
+
+
+
+
+    if (troy::utils::compression::available(CompressionMode::Zstd)) {
+        // Optionally, one can use Zstandard to compress the serialized objects,
+        // by providing the compression mode to the save functions. The load functions will automatically
+        // decompress it.
+        // This feature requires that you provide "TROY_ZSTD" in the CMake configuration,
+        // which is on by default.
+        stringstream ct_stream5;
+        encrypted.save(ct_stream5, context, CompressionMode::Zstd);
+        // We can see this has a smaller size.
+        std::cout << "Ciphertext asymmetrical compressed size = " << ct_stream5.str().size() << " bytes" << std::endl;
+    }
 
     std::cout << std::endl;
     

--- a/pybind/src/basics.cu
+++ b/pybind/src/basics.cu
@@ -16,6 +16,11 @@ void register_basics(pybind11::module& m) {
         .value("Classical256", SecurityLevel::Classical256)
     ;
 
+    py::enum_<CompressionMode>(m, "CompressionMode")
+        .value("Nil", CompressionMode::Nil)
+        .value("Zstd", CompressionMode::Zstd)
+    ;
+
     py::class_<MemoryPool, std::shared_ptr<MemoryPool>>(m, "MemoryPool")
         .def_static("global_pool", &MemoryPool::GlobalPool)
         .def(py::init([](size_t device){

--- a/pybind/src/ciphertext.cu
+++ b/pybind/src/ciphertext.cu
@@ -32,16 +32,19 @@ void register_ciphertext(pybind11::module& m) {
         .def("contains_seed", &Ciphertext::contains_seed)
         .def("expand_seed", &Ciphertext::expand_seed)
         .def("is_transparent", &Ciphertext::is_transparent)
-        .def("save", [](const Ciphertext& self, HeContextPointer context) {return save_he(self, context); })
+
+        .def("save", [](const Ciphertext& self, HeContextPointer context, CompressionMode mode) {return save_he(self, context, mode); },
+            py::arg("context"), COMPRESSION_MODE_ARGUMENT)
         .def("load", [](Ciphertext& self, const py::bytes& str, HeContextPointer context, MemoryPoolHandleArgument pool) {return load_he<Ciphertext>(self, str, context, nullopt_default_pool(pool)); },
             py::arg("str"), py::arg("context"), MEMORY_POOL_ARGUMENT)
         .def_static("load_new", [](const py::bytes& str, HeContextPointer context, MemoryPoolHandleArgument pool) {return load_new_he<Ciphertext>(str, context, nullopt_default_pool(pool)); },
             py::arg("str"), py::arg("context"), MEMORY_POOL_ARGUMENT)
-        .def("serialized_size", [](const Ciphertext& self, HeContextPointer context) {return serialized_size_he(self, context); })
-        .def("save_terms", [](const Ciphertext& self, HeContextPointer context, const py::array_t<size_t>& terms, MemoryPoolHandleArgument pool) {
-            ostringstream ss; self.save_terms(ss, context, get_vector_from_buffer(terms), nullopt_default_pool(pool)); 
+        .def("serialized_size_upperbound", [](const Ciphertext& self, HeContextPointer context, CompressionMode mode) {return serialized_size_upperbound_he(self, context, mode); },
+            py::arg("context") = nullptr, COMPRESSION_MODE_ARGUMENT)
+        .def("save_terms", [](const Ciphertext& self, HeContextPointer context, const py::array_t<size_t>& terms, MemoryPoolHandleArgument pool, CompressionMode mode) {
+            ostringstream ss; self.save_terms(ss, context, get_vector_from_buffer(terms), nullopt_default_pool(pool), mode); 
             return py::bytes(ss.str());
-        }, py::arg("context"), py::arg("terms"), MEMORY_POOL_ARGUMENT)
+        }, py::arg("context"), py::arg("terms"), MEMORY_POOL_ARGUMENT, COMPRESSION_MODE_ARGUMENT)
         .def("load_terms", [](Ciphertext& self, const py::bytes& str, HeContextPointer context, const py::array_t<size_t>& terms, MemoryPoolHandleArgument pool) {
             istringstream ss(str); self.load_terms(ss, context, get_vector_from_buffer(terms), nullopt_default_pool(pool)); 
         }, py::arg("str"), py::arg("context"), py::arg("terms"), MEMORY_POOL_ARGUMENT)
@@ -49,9 +52,9 @@ void register_ciphertext(pybind11::module& m) {
             istringstream ss(str); Ciphertext c; c.load_terms(ss, context, get_vector_from_buffer(terms), nullopt_default_pool(pool)); 
             return c;
         }, py::arg("str"), py::arg("context"), py::arg("terms"), MEMORY_POOL_ARGUMENT)
-        .def("serialized_terms_size", [](const Ciphertext& self, HeContextPointer context, const py::array_t<size_t>& terms) {
-            return self.serialized_terms_size(context, get_vector_from_buffer(terms));
-        })
+        .def("serialized_terms_size_upperbound", [](const Ciphertext& self, HeContextPointer context, const py::array_t<size_t>& terms, CompressionMode mode) {
+            return self.serialized_terms_size_upperbound(context, get_vector_from_buffer(terms), mode);
+        }, py::arg("context"), py::arg("terms"), COMPRESSION_MODE_ARGUMENT)
     ;
     
 }

--- a/pybind/src/encryption_parameters.cu
+++ b/pybind/src/encryption_parameters.cu
@@ -40,6 +40,17 @@ void register_encryption_parameters(pybind11::module& m) {
         })
         .def("__str__", [](const EncryptionParameters& self){ return to_string(self); })
         .def("__repr__", [](const EncryptionParameters& self){ return to_string(self); })
+    
+        .def("save", [](const EncryptionParameters& self) {
+            std::ostringstream ss; self.save(ss); return py::bytes(ss.str());
+        })
+        .def("load", [](EncryptionParameters& self, const py::bytes& str) {
+            std::istringstream ss(str); self.load(ss);
+        })
+        .def_static("load_new", [](const py::bytes& str) {
+            std::istringstream ss(str); EncryptionParameters ret; ret.load(ss); return ret;
+        })
+        .def("serialized_size_upperbound", &EncryptionParameters::serialized_size_upperbound)
     ;
     
 }

--- a/pybind/src/header.h
+++ b/pybind/src/header.h
@@ -111,9 +111,9 @@ std::string to_string(const T& object) {
 }
 
 template <typename T>
-py::bytes save(const T& object) {
+py::bytes save(const T& object, CompressionMode mode) {
     std::ostringstream ss;
-    object.save(ss);
+    object.save(ss, mode);
     return py::bytes(ss.str());
 }
 
@@ -133,14 +133,14 @@ T load_new(const py::bytes& str, MemoryPoolHandle pool) {
 
 
 template <typename T>
-size_t serialized_size(const T& object) {
-    return object.serialized_size();
+size_t serialized_size_upperbound(const T& object, CompressionMode mode) {
+    return object.serialized_size_upperbound(mode);
 }
 
 template <typename T>
-py::bytes save_he(const T& object, HeContextPointer context) {
+py::bytes save_he(const T& object, HeContextPointer context, CompressionMode mode) {
     std::ostringstream ss;
-    object.save(ss, context);
+    object.save(ss, context, mode);
     return py::bytes(ss.str());
 }
 
@@ -160,8 +160,8 @@ T load_new_he(const py::bytes& str, HeContextPointer context, MemoryPoolHandle p
 
 
 template <typename T>
-size_t serialized_size_he(const T& object, HeContextPointer context) {
-    return object.serialized_size(context);
+size_t serialized_size_upperbound_he(const T& object, HeContextPointer context, CompressionMode mode) {
+    return object.serialized_size_upperbound(context, mode);
 }
 
 typedef std::optional<MemoryPoolHandle> MemoryPoolHandleArgument;
@@ -174,6 +174,7 @@ inline MemoryPoolHandle nullopt_default_pool(MemoryPoolHandleArgument pool) {
 }
 
 #define MEMORY_POOL_ARGUMENT py::arg_v("pool", std::nullopt, "MemoryPool.global_pool()")
+#define COMPRESSION_MODE_ARGUMENT py::arg_v("mode", CompressionMode::Nil, "CompressionMode.Nil")
 #define OPTIONAL_PARMS_ID_ARGUMENT py::arg("parms_id") = std::nullopt
 
 void register_basics(pybind11::module& m);

--- a/pybind/src/kswitch_keys.cu
+++ b/pybind/src/kswitch_keys.cu
@@ -21,14 +21,16 @@ static void register_keyswitch_key_derived(pybind11::module& m, const char* name
         .def("on_device", &K::on_device)
         .def("parms_id", py::overload_cast<>(&K::parms_id, py::const_), py::return_value_policy::reference)
         .def("set_parms_id", [](K& self, const ParmsID& parms_id){ self.parms_id() = parms_id; })
-        .def("save", [](const K& self, HeContextPointer context) {return save_he(self, context); })
-        .def("load", [](K& self, const py::bytes& str, HeContextPointer context, MemoryPoolHandleArgument pool) {
-            return load_he<K>(self, str, context, nullopt_default_pool(pool));
-        }, py::arg("str"), py::arg("context"), MEMORY_POOL_ARGUMENT)
-        .def_static("load_new", [](const py::bytes& str, HeContextPointer context, MemoryPoolHandleArgument pool) {
-            return load_new_he<K>(str, context, nullopt_default_pool(pool));
-        }, py::arg("str"), py::arg("context"), MEMORY_POOL_ARGUMENT)
-        .def("serialized_size", [](const K& self, HeContextPointer context) {return serialized_size_he(self, context); })
+        
+        .def("save", [](const K& self, HeContextPointer context, CompressionMode mode) {return save_he(self, context, mode); },
+            py::arg("context"), COMPRESSION_MODE_ARGUMENT)
+        .def("load", [](K& self, const py::bytes& str, HeContextPointer context, MemoryPoolHandleArgument pool) {return load_he<K>(self, str, context, nullopt_default_pool(pool)); },
+            py::arg("str"), py::arg("context"), MEMORY_POOL_ARGUMENT)
+        .def_static("load_new", [](const py::bytes& str, HeContextPointer context, MemoryPoolHandleArgument pool) {return load_new_he<K>(str, context, nullopt_default_pool(pool)); },
+            py::arg("str"), py::arg("context"), MEMORY_POOL_ARGUMENT)
+        .def("serialized_size_upperbound", [](const K& self, HeContextPointer context, CompressionMode mode) {return serialized_size_upperbound_he(self, context, mode); },
+            py::arg("context") = nullptr, COMPRESSION_MODE_ARGUMENT)
+            
     ;
 
     if constexpr (as_keyswitch_keys) { 

--- a/pybind/src/plaintext.cu
+++ b/pybind/src/plaintext.cu
@@ -27,12 +27,15 @@ void register_plaintext(pybind11::module& m) {
         .def("resize", &Plaintext::resize)
         .def("is_ntt_form", py::overload_cast<>(&Plaintext::is_ntt_form, py::const_))
         .def("set_is_ntt_form", [](Plaintext& self, bool is_ntt_form){ self.is_ntt_form() = is_ntt_form; })
-        .def("save", [](const Plaintext& self) {return save(self); })
+        
+        .def("save", [](const Plaintext& self, CompressionMode mode) {return save(self, mode); },
+            COMPRESSION_MODE_ARGUMENT)
         .def("load", [](Plaintext& self, const py::bytes& str, MemoryPoolHandleArgument pool) {return load<Plaintext>(self, str, nullopt_default_pool(pool)); },
             py::arg("str"), MEMORY_POOL_ARGUMENT)
         .def_static("load_new", [](const py::bytes& str, MemoryPoolHandleArgument pool) {return load_new<Plaintext>(str, nullopt_default_pool(pool)); },
             py::arg("str"), MEMORY_POOL_ARGUMENT)
-        .def("serialized_size", [](const Plaintext& self) {return serialized_size(self); })
+        .def("serialized_size_upperbound", [](const Plaintext& self, CompressionMode mode) {return serialized_size_upperbound(self, mode); }
+            , COMPRESSION_MODE_ARGUMENT)
     ;
 
 }

--- a/pybind/src/public_key.cu
+++ b/pybind/src/public_key.cu
@@ -25,14 +25,16 @@ void register_public_key(pybind11::module& m) {
         .def("get_ciphertext", [](const PublicKey& self, MemoryPoolHandleArgument pool) {
             return self.as_ciphertext().clone(nullopt_default_pool(pool)); 
         }, MEMORY_POOL_ARGUMENT)
-        .def("save", [](const PublicKey& self, HeContextPointer context) {return save_he(self, context); })
-        .def("load", [](PublicKey& self, const py::bytes& str, HeContextPointer context, MemoryPoolHandleArgument pool) {
-            return load_he<PublicKey>(self, str, context, nullopt_default_pool(pool)); 
-        }, py::arg("str"), py::arg("context"), MEMORY_POOL_ARGUMENT)
-        .def_static("load_new", [](const py::bytes& str, HeContextPointer context, MemoryPoolHandleArgument pool) {
-            return load_new_he<PublicKey>(str, context, nullopt_default_pool(pool));
-        }, py::arg("str"), py::arg("context"), MEMORY_POOL_ARGUMENT)
-        .def("serialized_size", [](const PublicKey& self, HeContextPointer context) {return serialized_size_he(self, context); })
+
+        .def("save", [](const PublicKey& self, HeContextPointer context, CompressionMode mode) {return save_he(self, context, mode); },
+            py::arg("context"), COMPRESSION_MODE_ARGUMENT)
+        .def("load", [](PublicKey& self, const py::bytes& str, HeContextPointer context, MemoryPoolHandleArgument pool) {return load_he<PublicKey>(self, str, context, nullopt_default_pool(pool)); },
+            py::arg("str"), py::arg("context"), MEMORY_POOL_ARGUMENT)
+        .def_static("load_new", [](const py::bytes& str, HeContextPointer context, MemoryPoolHandleArgument pool) {return load_new_he<PublicKey>(str, context, nullopt_default_pool(pool)); },
+            py::arg("str"), py::arg("context"), MEMORY_POOL_ARGUMENT)
+        .def("serialized_size_upperbound", [](const PublicKey& self, HeContextPointer context, CompressionMode mode) {return serialized_size_upperbound_he(self, context, mode); },
+            py::arg("context") = nullptr, COMPRESSION_MODE_ARGUMENT)
+
         .def("contains_seed", &PublicKey::contains_seed)
         .def("expand_seed", &PublicKey::expand_seed)
     ;

--- a/pybind/src/secret_key.cu
+++ b/pybind/src/secret_key.cu
@@ -21,14 +21,16 @@ void register_secret_key(pybind11::module& m) {
         .def("on_device", &SecretKey::on_device)
         .def("parms_id", py::overload_cast<>(&SecretKey::parms_id, py::const_), py::return_value_policy::reference)
         .def("set_parms_id", [](SecretKey& self, const ParmsID& parms_id){ self.parms_id() = parms_id; })
-        .def("save", [](const SecretKey& self) {return save(self); })
+        .def("save", [](const SecretKey& self, CompressionMode mode) {return save(self, mode); }
+            , COMPRESSION_MODE_ARGUMENT)
         .def("load", [](SecretKey& self, const py::bytes& str, MemoryPoolHandleArgument pool) {
             return load<SecretKey>(self, str, nullopt_default_pool(pool)); 
         }, py::arg("str"), MEMORY_POOL_ARGUMENT)
         .def_static("load_new", [](const py::bytes& str, MemoryPoolHandleArgument pool) {
             return load_new<SecretKey>(str, nullopt_default_pool(pool)); 
         }, py::arg("str"), MEMORY_POOL_ARGUMENT)
-        .def("serialized_size", [](const SecretKey& self) {return serialized_size(self); })
+        .def("serialized_size_upperbound", [](const SecretKey& self, CompressionMode mode) {return serialized_size_upperbound(self, mode); }
+            , COMPRESSION_MODE_ARGUMENT)
         .def("as_plaintext", [](const SecretKey& self) {return self.as_plaintext(); }, py::return_value_policy::reference)
         .def("get_plaintext", [](const SecretKey& self, MemoryPoolHandleArgument pool) {return self.as_plaintext().clone(nullopt_default_pool(pool)); },
             MEMORY_POOL_ARGUMENT)

--- a/pybind/tests/test_matmul.py
+++ b/pybind/tests/test_matmul.py
@@ -216,12 +216,12 @@ class HeRing2kMatmulTest:
         automorphism_keys = self.automorphism_keys
         
         if self.t_bits > 32:
-            x_encoded = helper.encode_inputs_ring2k64(encoder, x.data, None)
-            w_encoded = helper.encode_weights_ring2k64(encoder, w.data, None)
+            x_encoded = helper.encode_inputs_ring2k64(encoder, x.data, None, True)
+            w_encoded = helper.encode_weights_ring2k64(encoder, w.data, None, False)
             s_encoded = helper.encode_outputs_ring2k64(encoder, s.data, None)
         else:
-            x_encoded = helper.encode_inputs_ring2k32(encoder, x.data, None)
-            w_encoded = helper.encode_weights_ring2k32(encoder, w.data, None)
+            x_encoded = helper.encode_inputs_ring2k32(encoder, x.data, None, True)
+            w_encoded = helper.encode_weights_ring2k32(encoder, w.data, None, False)
             s_encoded = helper.encode_outputs_ring2k32(encoder, s.data, None)
 
         x_encrypted = x_encoded.encrypt_symmetric(encryptor)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,13 @@ if(TROY_MEMORY_POOL_UNSAFE)
   target_compile_definitions(troy_static PUBLIC TROY_MEMORY_POOL_UNSAFE)
 endif()
 
+if(TROY_ZSTD)
+  target_compile_definitions(troy        PUBLIC TROY_ZSTD)
+  target_compile_definitions(troy_static PUBLIC TROY_ZSTD)
+  target_link_libraries(troy        PRIVATE libzstd_static)
+  target_link_libraries(troy_static PRIVATE libzstd_static)
+endif()
+
 install(TARGETS troy troy_static
   EXPORT troyTargets
   LIBRARY DESTINATION lib

--- a/src/app/cipher2d.cu
+++ b/src/app/cipher2d.cu
@@ -26,15 +26,16 @@ namespace troy { namespace linear {
         return encrypt_internal(encryptor, true, pool);
     }
 
-    void Cipher2d::save(std::ostream& stream, HeContextPointer context) const {
+    size_t Cipher2d::save(std::ostream& stream, HeContextPointer context, CompressionMode mode) const {
         troy::serialize::save_object(stream, (*this).rows());
         for (size_t i = 0; i < this->rows(); i++) {
             size_t row_size = (*this)[i].size();
             troy::serialize::save_object(stream, row_size);
             for (size_t j = 0; j < row_size; j++) {
-                (*this)[i][j].save(stream, context);
+                (*this)[i][j].save(stream, context, mode);
             }
         }
+        return this->serialized_size_upperbound(context, mode);
     }
 
     void Cipher2d::load(std::istream& stream, HeContextPointer context, MemoryPoolHandle pool) {
@@ -53,14 +54,13 @@ namespace troy { namespace linear {
         }
     }
     
-    size_t Cipher2d::serialized_size(HeContextPointer context) const {
-        throw std::runtime_error("[Cipher2d::serialized_size] Not implemented.");
+    size_t Cipher2d::serialized_size_upperbound(HeContextPointer context, CompressionMode mode) const {
         size_t bytes = 0;
         bytes += sizeof(size_t); // rows
         for (size_t i = 0; i < this->rows(); i++) {
             bytes += sizeof(size_t); // row size
             for (size_t j = 0; j < (*this)[i].size(); j++) {
-                bytes += (*this)[i][j].serialized_size(context);
+                bytes += (*this)[i][j].serialized_size_upperbound(context, mode);
             }
         }
         return bytes;

--- a/src/app/cipher2d.h
+++ b/src/app/cipher2d.h
@@ -152,14 +152,14 @@ namespace troy { namespace linear {
             }
         }
 
-        void save(std::ostream& stream, HeContextPointer context) const;
+        size_t save(std::ostream& stream, HeContextPointer context, CompressionMode mode = CompressionMode::Nil) const;
         void load(std::istream& stream, HeContextPointer context, MemoryPoolHandle pool = MemoryPool::GlobalPool());
         inline static Cipher2d load_new(std::istream& stream, HeContextPointer context, MemoryPoolHandle pool = MemoryPool::GlobalPool()) {
             Cipher2d result;
             result.load(stream, context, pool);
             return result;
         }
-        size_t serialized_size(HeContextPointer context) const;
+        size_t serialized_size_upperbound(HeContextPointer context, CompressionMode mode = CompressionMode::Nil) const;
 
         inline void mod_switch_to_next_inplace(const Evaluator& evaluator, MemoryPoolHandle pool = MemoryPool::GlobalPool()) {
             for (std::vector<Ciphertext>& row : this->data()) {

--- a/src/app/matmul.cu
+++ b/src/app/matmul.cu
@@ -586,7 +586,7 @@ namespace troy { namespace linear {
         return ret;
     }
 
-    void MatmulHelper::serialize_encoded_weights(const Plain2d& w, std::ostream& stream) const {
+    void MatmulHelper::serialize_encoded_weights(const Plain2d& w, std::ostream& stream, CompressionMode mode) const {
         size_t rows = w.data().size();
         size_t cols = w[0].size();
         if (rows == 0) throw std::invalid_argument("[MatmulHelper::serialize_encoded_weights] No rows in weight matrix.");
@@ -598,7 +598,7 @@ namespace troy { namespace linear {
         serialize::save_object(stream, cols);
         for (size_t i = 0; i < rows; i++) {
             for (size_t j = 0; j < cols; j++) {
-                w[i][j].save(stream);
+                w[i][j].save(stream, mode);
             }
         }
     }
@@ -620,7 +620,7 @@ namespace troy { namespace linear {
         return ret;
     }
 
-    void MatmulHelper::serialize_outputs(const Evaluator &evaluator, const Cipher2d& x, std::ostream& stream) const {
+    void MatmulHelper::serialize_outputs(const Evaluator &evaluator, const Cipher2d& x, std::ostream& stream, CompressionMode mode) const {
         HeContextPointer context = evaluator.context();
         if (!this->pack_lwe) {
             size_t vecsize = output_block;
@@ -635,7 +635,7 @@ namespace troy { namespace linear {
                     for (size_t i = li; i < ui; i++)
                         for (size_t j = lj; j < uj; j++) 
                             required[rid++] = (i - li) * input_block * output_block + (j - lj) * input_block + input_block - 1;
-                    x[di][dj].save_terms(stream, context, required, pool);
+                    x[di][dj].save_terms(stream, context, required, pool, mode);
                     dj += 1;
                 }
                 di += 1;
@@ -647,7 +647,7 @@ namespace troy { namespace linear {
                 throw std::invalid_argument("[MatmulHelper::serialize_outputs] Output ciphertext count incorrect");
             }
             for (size_t i = 0; i < x.data()[0].size(); i++) {
-                x[0][i].save(stream, context);
+                x[0][i].save(stream, context, mode);
             }
         }
     }

--- a/src/app/matmul.h
+++ b/src/app/matmul.h
@@ -45,8 +45,8 @@ namespace troy { namespace linear {
         size_t slot_count;
         size_t batch_block, input_block, output_block;
         MatmulObjective objective; 
-        MemoryPoolHandle pool;
         bool pack_lwe;
+        MemoryPoolHandle pool;
 
         inline void set_pool(MemoryPoolHandle pool) {
             this->pool = pool;
@@ -90,9 +90,9 @@ namespace troy { namespace linear {
 
         Cipher2d pack_outputs(const Evaluator& evaluator, const GaloisKeys& autoKey, const Cipher2d& cipher) const;
 
-        void serialize_encoded_weights(const Plain2d& w, std::ostream& stream) const;
+        void serialize_encoded_weights(const Plain2d& w, std::ostream& stream, CompressionMode mode = CompressionMode::Nil) const;
         Plain2d deserialize_encoded_weights(std::istream& stream) const;
-        void serialize_outputs(const Evaluator &evaluator, const Cipher2d& x, std::ostream& stream) const;
+        void serialize_outputs(const Evaluator &evaluator, const Cipher2d& x, std::ostream& stream, CompressionMode mode = CompressionMode::Nil) const;
         Cipher2d deserialize_outputs(const Evaluator &evaluator, std::istream& stream) const;
 
     };

--- a/src/ciphertext.cu
+++ b/src/ciphertext.cu
@@ -49,7 +49,7 @@ namespace troy {
         this->seed() = 0;
     }
 
-    void Ciphertext::save(std::ostream& stream, HeContextPointer context) const {
+    size_t Ciphertext::save_raw(std::ostream& stream, HeContextPointer context) const {
         serialize::save_object(stream, this->parms_id());
         serialize::save_object(stream, this->polynomial_count());
         serialize::save_object(stream, this->coeff_modulus_size());
@@ -94,9 +94,10 @@ namespace troy {
                 serialize::save_array(stream, this->data().raw_pointer(), this->data().size());
             }
         }
+        return this->serialized_raw_size(context);
     }
 
-    void Ciphertext::load(std::istream& stream, HeContextPointer context, MemoryPoolHandle pool) {
+    void Ciphertext::load_raw(std::istream& stream, HeContextPointer context, MemoryPoolHandle pool) {
         serialize::load_object(stream, this->parms_id());
         serialize::load_object(stream, this->polynomial_count_);
         serialize::load_object(stream, this->coeff_modulus_size_);
@@ -145,7 +146,7 @@ namespace troy {
 
     }
     
-    size_t Ciphertext::serialized_size(HeContextPointer context) const {
+    size_t Ciphertext::serialized_raw_size(HeContextPointer context) const {
         size_t size = 0;
         size += sizeof(ParmsID); // parms_id
         size += sizeof(size_t); // polynomial_count
@@ -168,7 +169,7 @@ namespace troy {
         return size;
     }
 
-    void Ciphertext::save_terms(std::ostream& stream, HeContextPointer context, const std::vector<size_t>& terms, MemoryPoolHandle pool) const {
+    size_t Ciphertext::save_terms_raw(std::ostream& stream, HeContextPointer context, const std::vector<size_t>& terms, MemoryPoolHandle pool) const {
         serialize::save_object(stream, this->parms_id());
         serialize::save_object(stream, this->polynomial_count());
         serialize::save_object(stream, this->coeff_modulus_size());
@@ -232,10 +233,12 @@ namespace troy {
             utils::ConstSlice<uint64_t> data = this->polys(start_polynomial, this->polynomial_count_);
             serialize::save_array(stream, data.raw_pointer(), data.size());
         }
+
+        return this->serialized_terms_raw_size(context, terms);
     }
 
     
-    void Ciphertext::load_terms(std::istream& stream, HeContextPointer context, const std::vector<size_t>& terms, MemoryPoolHandle pool) {
+    void Ciphertext::load_terms_raw(std::istream& stream, HeContextPointer context, const std::vector<size_t>& terms, MemoryPoolHandle pool) {
         serialize::load_object(stream, this->parms_id());
         serialize::load_object(stream, this->polynomial_count_);
         serialize::load_object(stream, this->coeff_modulus_size_);
@@ -294,7 +297,7 @@ namespace troy {
         if (contains_seed) this->expand_seed(context);
     }
 
-    size_t Ciphertext::serialized_terms_size(HeContextPointer context, const std::vector<size_t>& terms) const {
+    size_t Ciphertext::serialized_terms_raw_size(HeContextPointer context, const std::vector<size_t>& terms) const {
         size_t size = 0;
         size += sizeof(ParmsID); // parms_id
         size += sizeof(size_t); // polynomial_count

--- a/src/encryption_parameters.cu
+++ b/src/encryption_parameters.cu
@@ -1,4 +1,5 @@
 #include "encryption_parameters.h"
+#include "utils/serialize.h"
 
 namespace troy {
 
@@ -48,4 +49,67 @@ namespace troy {
         os << "}, PlainModulus = " << parms.plain_modulus()->value() << " }";
         return os;
     }
+
+    size_t EncryptionParameters::save(std::ostream& stream) const {
+        if (this->on_device()) {
+            throw std::logic_error("[EncryptionParameters::save] Cannot save a device EncryptionParameters.");
+        }
+        serialize::save_object(stream, this->scheme());
+        serialize::save_object(stream, this->poly_modulus_degree());
+        serialize::save_object(stream, this->coeff_modulus().size());
+        for (size_t i = 0; i < coeff_modulus().size(); i++) {
+            serialize::save_object(stream, this->coeff_modulus()[i].value());
+        }
+        if (scheme() == SchemeType::BFV || scheme() == SchemeType::BGV) {
+            serialize::save_object(stream, this->plain_modulus()->value());
+        }
+        serialize::save_object(stream, this->use_special_prime_for_encryption());
+        return serialized_size_upperbound();
+    }
+
+    size_t EncryptionParameters::serialized_size_upperbound() const {
+        size_t size = 0;
+        size += sizeof(SchemeType);
+        size += sizeof(size_t);
+        size += sizeof(size_t);
+        size += coeff_modulus().size() * sizeof(uint64_t);
+        if (scheme() == SchemeType::BFV || scheme() == SchemeType::BGV) {
+            size += sizeof(uint64_t);
+        }
+        size += sizeof(bool);
+        return size;
+    }
+
+    void EncryptionParameters::load(std::istream& stream) {
+        if (this->on_device()) {
+            throw std::logic_error("[EncryptionParameters::load] Cannot load into a device EncryptionParameters.");
+        }
+        SchemeType scheme;
+        size_t poly_modulus_degree;
+        size_t coeff_modulus_size;
+        serialize::load_object(stream, scheme);
+        this->scheme_ = scheme;
+        serialize::load_object(stream, poly_modulus_degree);
+        this->set_poly_modulus_degree(poly_modulus_degree);
+        serialize::load_object(stream, coeff_modulus_size);
+        std::vector<Modulus> coeff_modulus;
+        for (size_t i = 0; i < coeff_modulus_size; i++) {
+            uint64_t value;
+            serialize::load_object(stream, value);
+            coeff_modulus.push_back(Modulus(value));
+        }
+        this->set_coeff_modulus(coeff_modulus);
+        if (scheme == SchemeType::BFV || scheme == SchemeType::BGV) {
+            Modulus plain_modulus;
+            uint64_t value;
+            serialize::load_object(stream, value);
+            plain_modulus = Modulus(value);
+            this->set_plain_modulus(plain_modulus);
+        }
+        bool use_special_prime_for_encryption;
+        serialize::load_object(stream, use_special_prime_for_encryption);
+        this->set_use_special_prime_for_encryption(use_special_prime_for_encryption);
+        this->compute_parms_id();
+    }
+
 }

--- a/src/encryption_parameters.h
+++ b/src/encryption_parameters.h
@@ -61,14 +61,15 @@ namespace troy {
         inline EncryptionParameters() : EncryptionParameters(SchemeType::Nil) {}
 
         inline EncryptionParameters(const EncryptionParameters& parms):
+            device(parms.device),
+            use_special_prime_for_encryption_(parms.use_special_prime_for_encryption_),
             scheme_(parms.scheme_),
             parms_id_(parms.parms_id_),
             poly_modulus_degree_(parms.poly_modulus_degree_),
             coeff_modulus_(parms.coeff_modulus_.clone(parms.pool())),
             plain_modulus_(parms.plain_modulus_.clone(parms.pool())),
-            plain_modulus_host_(parms.plain_modulus_host_),
-            use_special_prime_for_encryption_(parms.use_special_prime_for_encryption_),
-            device(parms.device) {}
+            plain_modulus_host_(parms.plain_modulus_host_)
+            {}
             
         EncryptionParameters(EncryptionParameters&& parms) = default;
 
@@ -219,6 +220,15 @@ namespace troy {
             cloned.to_host_inplace();
             return cloned;
         }
+
+        size_t save(std::ostream& stream) const;
+        void load(std::istream& stream);
+        inline static EncryptionParameters load_new(std::istream& stream) {
+            EncryptionParameters parms;
+            parms.load(stream);
+            return parms;
+        }
+        size_t serialized_size_upperbound() const;
 
     };
 

--- a/src/key.h
+++ b/src/key.h
@@ -70,8 +70,8 @@ namespace troy {
             return sk.data();
         }
 
-        inline void save(std::ostream& stream) const {
-            sk.save(stream);
+        inline size_t save(std::ostream& stream, CompressionMode mode = CompressionMode::Nil) const {
+            return sk.save(stream, mode);
         }
         inline void load(std::istream& stream, MemoryPoolHandle pool = MemoryPool::GlobalPool()) {
             sk.load(stream, pool);
@@ -81,8 +81,8 @@ namespace troy {
             sk.load(stream, pool);
             return sk;
         }
-        inline size_t serialized_size() const {
-            return sk.serialized_size();
+        inline size_t serialized_size_upperbound(CompressionMode mode = CompressionMode::Nil) const {
+            return sk.serialized_size_upperbound(mode);
         }
 
     };
@@ -160,8 +160,8 @@ namespace troy {
             pk.expand_seed(context);
         }
 
-        inline void save(std::ostream& stream, HeContextPointer context) const {
-            pk.save(stream, context);
+        inline size_t save(std::ostream& stream, HeContextPointer context, CompressionMode mode = CompressionMode::Nil) const {
+            return pk.save(stream, context, mode);
         }
         inline void load(std::istream& stream, HeContextPointer context, MemoryPoolHandle pool = MemoryPool::GlobalPool()) {
             pk.load(stream, context, pool);
@@ -171,8 +171,8 @@ namespace troy {
             result.load(stream, context, pool);
             return result;
         }
-        inline size_t serialized_size(HeContextPointer context) const {
-            return pk.serialized_size(context);
+        inline size_t serialized_size_upperbound(HeContextPointer context, CompressionMode mode = CompressionMode::Nil) const {
+            return pk.serialized_size_upperbound(context, mode);
         }
     };
 

--- a/src/kswitch_keys.cu
+++ b/src/kswitch_keys.cu
@@ -2,10 +2,13 @@
 
 namespace troy {
 
-    void KSwitchKeys::save(std::ostream& stream, HeContextPointer context) const {
+    size_t KSwitchKeys::save(std::ostream& stream, HeContextPointer context, CompressionMode mode) const {
+        size_t total = 0;
         serialize::save_object(stream, this->parms_id());
+        total += sizeof(this->parms_id());
         size_t size1d = this->data().size();
         serialize::save_object(stream, size1d);
+        total += sizeof(size1d);
         size_t valid_count = 0;
         for (size_t i = 0; i < size1d; i++) {
             if (this->data()[i].size() > 0) {
@@ -13,16 +16,20 @@ namespace troy {
             }
         }
         serialize::save_object(stream, valid_count);
+        total += sizeof(valid_count);
         for (size_t i = 0; i < size1d; i++) {
             if (this->data()[i].size() == 0) continue;
             size_t size2d = this->data()[i].size();
             // save id
             serialize::save_object(stream, i);
+            total += sizeof(i);
             serialize::save_object(stream, size2d);
+            total += sizeof(size2d);
             for (size_t j = 0; j < size2d; j++) {
-                this->data()[i][j].save(stream, context);
+                total += this->data()[i][j].save(stream, context, mode);
             }
         }
+        return total;
     }
 
     void KSwitchKeys::load(std::istream& stream, HeContextPointer context, MemoryPoolHandle pool) {
@@ -45,7 +52,7 @@ namespace troy {
         }
     }
 
-    size_t KSwitchKeys::serialized_size(HeContextPointer context) const {
+    size_t KSwitchKeys::serialized_size_upperbound(HeContextPointer context, CompressionMode mode) const {
         size_t bytes = 0;
         bytes += sizeof(this->parms_id());
         size_t size1d = this->data().size();
@@ -64,7 +71,7 @@ namespace troy {
             bytes += sizeof(i);
             bytes += sizeof(size2d);
             for (size_t j = 0; j < size2d; j++) {
-                bytes += this->data()[i][j].serialized_size(context);
+                bytes += this->data()[i][j].serialized_size_upperbound(context, mode);
             }
         }
         return bytes;

--- a/src/kswitch_keys.h
+++ b/src/kswitch_keys.h
@@ -149,14 +149,14 @@ namespace troy {
             }
         }
 
-        void save(std::ostream& stream, HeContextPointer context) const;
+        size_t save(std::ostream& stream, HeContextPointer context, CompressionMode mode = CompressionMode::Nil) const;
         void load(std::istream& stream, HeContextPointer context, MemoryPoolHandle pool = MemoryPool::GlobalPool());
         inline static KSwitchKeys load_new(std::istream& stream, HeContextPointer context, MemoryPoolHandle pool = MemoryPool::GlobalPool()) {
             KSwitchKeys result;
             result.load(stream, context, pool);
             return result;
         }
-        size_t serialized_size(HeContextPointer context) const;
+        size_t serialized_size_upperbound(HeContextPointer context, CompressionMode mode = CompressionMode::Nil) const;
 
     };
 
@@ -240,8 +240,8 @@ namespace troy {
             keys.expand_seed(context);
         }
         
-        inline void save(std::ostream& stream, HeContextPointer context) const {
-            keys.save(stream, context);
+        inline size_t save(std::ostream& stream, HeContextPointer context, CompressionMode mode = CompressionMode::Nil) const {
+            return keys.save(stream, context, mode);
         }
         inline void load(std::istream& stream, HeContextPointer context, MemoryPoolHandle pool = MemoryPool::GlobalPool()) {
             keys.load(stream, context, pool);
@@ -251,8 +251,8 @@ namespace troy {
             result.load(stream, context, pool);
             return result;
         }
-        size_t serialized_size(HeContextPointer context) const {
-            return keys.serialized_size(context);
+        size_t serialized_size_upperbound(HeContextPointer context, CompressionMode mode = CompressionMode::Nil) const {
+            return keys.serialized_size_upperbound(context, mode);
         }
     };
 
@@ -333,8 +333,8 @@ namespace troy {
             keys.expand_seed(context);
         }
 
-        inline void save(std::ostream& stream, HeContextPointer context) const {
-            keys.save(stream, context);
+        inline size_t save(std::ostream& stream, HeContextPointer context, CompressionMode mode = CompressionMode::Nil) const {
+            return keys.save(stream, context, mode);
         }
         inline void load(std::istream& stream, HeContextPointer context, MemoryPoolHandle pool = MemoryPool::GlobalPool()) {
             keys.load(stream, context, pool);
@@ -344,8 +344,8 @@ namespace troy {
             result.load(stream, context, pool);
             return result;
         }
-        size_t serialized_size(HeContextPointer context) const {
-            return keys.serialized_size(context);
+        size_t serialized_size_upperbound(HeContextPointer context, CompressionMode mode = CompressionMode::Nil) const {
+            return keys.serialized_size_upperbound(context, mode);
         }
     };
 }

--- a/src/plaintext.cu
+++ b/src/plaintext.cu
@@ -2,7 +2,7 @@
 
 namespace troy {
 
-    void Plaintext::save(std::ostream& stream) const {
+    size_t Plaintext::save_raw(std::ostream& stream) const {
         serialize::save_object(stream, this->parms_id());
         serialize::save_object(stream, this->scale());
         serialize::save_object(stream, this->coeff_count_);
@@ -17,9 +17,10 @@ namespace troy {
         serialize::save_bool(stream, this->is_ntt_form());
         serialize::save_object(stream, this->poly_modulus_degree());
         serialize::save_object(stream, this->coeff_modulus_size());
+        return this->serialized_raw_size();
     }
 
-    void Plaintext::load(std::istream& stream, MemoryPoolHandle pool) {
+    void Plaintext::load_raw(std::istream& stream, MemoryPoolHandle pool) {
         serialize::load_object(stream, this->parms_id());
         serialize::load_object(stream, this->scale());
         serialize::load_object(stream, this->coeff_count_);
@@ -38,7 +39,7 @@ namespace troy {
         serialize::load_object(stream, this->coeff_modulus_size());
     }
     
-    size_t Plaintext::serialized_size() const {
+    size_t Plaintext::serialized_raw_size() const {
         size_t size = 0;
         size += sizeof(ParmsID); // parms_id
         size += sizeof(double); // scale

--- a/src/utils/compression.h
+++ b/src/utils/compression.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <iostream>
+#include <stdexcept>
+
+namespace troy::utils::compression {
+
+    namespace zstd {
+        size_t compressed_size_upperbound(size_t input_size);
+        size_t compress(const void* input, size_t input_size, std::ostream& output);
+        size_t decompress(const void* input, size_t input_size, std::ostream& output);
+        bool available();
+    }
+
+    enum class CompressionMode: uint8_t {
+        Nil = 0,
+        Zstd = 1,
+    };
+
+    inline size_t compressed_size_upperbound(size_t input_size, CompressionMode mode) {
+        switch (mode) {
+            case CompressionMode::Nil: return input_size;
+            case CompressionMode::Zstd: return zstd::compressed_size_upperbound(input_size);
+        }
+        throw std::runtime_error("Invalid compression mode");
+    }
+    inline size_t compress(const void* input, size_t input_size, std::ostream& output, CompressionMode mode) {
+        switch (mode) {
+            case CompressionMode::Nil: {
+                throw std::invalid_argument("[utils::compression::compress] Should not call this function with CompressionMode::Nil");
+            }
+            case CompressionMode::Zstd: return zstd::compress(input, input_size, output);
+        }
+        throw std::runtime_error("Invalid compression mode");
+    
+    }
+    inline size_t decompress(const void* input, size_t input_size, std::ostream& output, CompressionMode mode) {
+        switch (mode) {
+            case CompressionMode::Nil: {
+                throw std::invalid_argument("[utils::compression::decompress] Should not call this function with CompressionMode::Nil");
+            }
+            case CompressionMode::Zstd: return zstd::decompress(input, input_size, output);
+        }
+        throw std::runtime_error("Invalid compression mode");
+    }
+    inline bool available(CompressionMode mode) {
+        switch (mode) {
+            case CompressionMode::Nil: return true;
+            case CompressionMode::Zstd: return zstd::available();
+        }
+        throw std::runtime_error("Invalid compression mode");
+    }
+
+}
+
+namespace troy {
+    using utils::compression::CompressionMode;
+}

--- a/src/utils/compression_zstd.cpp
+++ b/src/utils/compression_zstd.cpp
@@ -1,0 +1,131 @@
+#include "compression.h"
+
+#ifdef TROY_ZSTD
+
+#include <zstd.h>
+
+namespace troy::utils::compression::zstd {
+
+
+    bool available() {
+        return true;
+    }
+
+    void check_zstd(size_t error_code, const char* message) {
+        if (ZSTD_isError(error_code)) {
+            throw std::runtime_error(std::string(message) + message + " - " + ZSTD_getErrorName(error_code));
+        }
+    }
+    
+    size_t compressed_size_upperbound(size_t input_size) {
+        return ZSTD_compressBound(input_size);
+    }
+
+    size_t compress(const void* input, size_t input_size, std::ostream& output) {
+        if (input_size > ZSTD_MAX_INPUT_SIZE) {
+            throw std::invalid_argument("[utils::compression::zstd::compress] Input size is too large");
+        }
+        size_t buffer_size = std::min(input_size, ZSTD_CStreamOutSize());
+        uint8_t* buffer = new uint8_t[buffer_size];
+        size_t offset = 0;
+        size_t total_written = 0;
+
+        // create context
+        ZSTD_CCtx* cctx = ZSTD_createCCtx();
+        if (cctx == nullptr) {
+            throw std::runtime_error("[utils::compression::zstd::compress] ZSTD_createCCtx() failed");
+        }
+
+        // set parameters
+        size_t error = ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, ZSTD_CLEVEL_DEFAULT);
+        check_zstd(error, "[utils::compression::zstd::compress] ZSTD_CCtx_setParameter() failed");
+
+        size_t input_chunk_size = ZSTD_CStreamInSize();
+        bool finished = false;
+        while (offset < input_size) {
+            bool last_chunk = offset + input_chunk_size >= input_size;
+            ZSTD_EndDirective mode = last_chunk ? ZSTD_e_end : ZSTD_e_continue;
+            size_t input_process_chunk_size = last_chunk ? input_size - offset : input_chunk_size;
+            ZSTD_inBuffer input_buffer = { reinterpret_cast<const uint8_t*>(input) + offset, input_process_chunk_size, 0 };
+            do {
+                ZSTD_outBuffer output_buffer = { buffer, buffer_size, 0 };
+                size_t remaining = ZSTD_compressStream2(cctx, &output_buffer, &input_buffer, mode);
+                check_zstd(remaining, "[utils::compression::zstd::compress] ZSTD_compressStream() failed");
+                output.write(reinterpret_cast<const char*>(buffer), output_buffer.pos);
+                total_written += output_buffer.pos;
+                finished = last_chunk ? (remaining == 0) : (input_buffer.pos == input_buffer.size);
+            } while (!finished);
+            offset += input_process_chunk_size;
+        }
+
+        delete[] buffer;
+
+        // free context
+        ZSTD_freeCCtx(cctx);
+
+        return total_written;
+    }
+
+    size_t decompress(const void* input, size_t input_size, std::ostream& output) {
+        size_t buffer_size = ZSTD_DStreamOutSize();
+        uint8_t* buffer = new uint8_t[buffer_size];
+        size_t offset = 0;
+        size_t total_written = 0;
+
+        // create context
+        ZSTD_DCtx* dctx = ZSTD_createDCtx();
+        if (dctx == nullptr) {
+            throw std::runtime_error("[utils::compression::zstd::decompress] ZSTD_createDCtx() failed");
+        }
+
+        size_t input_chunk_size = ZSTD_DStreamInSize();
+        bool finished = false;
+        while (offset < input_size) {
+            size_t input_process_chunk_size = std::min(input_chunk_size, input_size - offset);
+            ZSTD_inBuffer input_buffer = { reinterpret_cast<const uint8_t*>(input) + offset, input_process_chunk_size, 0 };
+            do {
+                ZSTD_outBuffer output_buffer = { buffer, buffer_size, 0 };
+                size_t remaining = ZSTD_decompressStream(dctx, &output_buffer, &input_buffer);
+                check_zstd(remaining, "[utils::compression::zstd::decompress] ZSTD_decompressStream() failed");
+                output.write(reinterpret_cast<const char*>(buffer), output_buffer.pos);
+                total_written += output_buffer.pos;
+                finished = input_buffer.pos == input_buffer.size;
+            } while (!finished);
+            offset += input_process_chunk_size;
+        }
+
+        delete[] buffer;
+
+        // free context
+        ZSTD_freeDCtx(dctx);
+
+        return total_written;
+    }
+    
+}
+
+#else
+
+namespace troy::utils::compression::zstd {
+
+    void throw_it() {
+        throw std::runtime_error("[troy::utils::compression::zstd] Zstd is not enabled");
+    }
+
+    size_t compressed_size_upperbound(size_t input_size) {
+        throw_it();
+    }
+    size_t compress(const void* input, size_t input_size, std::ostream& output) {
+        throw_it();
+    }
+    size_t decompress(const void* input, size_t input_size, std::ostream& output) {
+        throw_it();
+    }
+
+    bool available() {
+        return false;
+    }
+
+}
+
+#endif

--- a/src/utils/serialize.h
+++ b/src/utils/serialize.h
@@ -1,6 +1,12 @@
 #pragma once
 #include <iostream>
+#include <sstream>
 #include "box.h"
+#include "compression.h"
+
+namespace troy {
+    class HeContext;
+}
 
 namespace troy {namespace serialize {
 
@@ -36,5 +42,75 @@ namespace troy {namespace serialize {
         }
         b = c;
     }
-    
+
+    inline size_t serialized_size_upperbound(size_t raw_size, CompressionMode mode) {
+        size_t compressed_size = utils::compression::compressed_size_upperbound(raw_size, mode);
+        return compressed_size + sizeof(CompressionMode) + sizeof(size_t);
+    }
+
+    // This struct is for obtaining the inner buffer of a std::stringbuf
+    struct StringBufWithRawPointer: public std::stringbuf {
+        inline char* get_buffer() {return this->pbase();}
+    };
+
+    template <typename R>
+    inline size_t compress(std::ostream& os, R save_raw, CompressionMode mode) {
+        if (mode == CompressionMode::Nil) {
+            StringBufWithRawPointer buf;
+            std::ostream ss(&buf);
+            size_t actual_size = save_raw(ss);
+            save_object(os, mode);
+            save_object(os, actual_size);
+            os.write(buf.get_buffer(), actual_size);
+            return actual_size + sizeof(CompressionMode) + sizeof(size_t);
+        } else {
+            // first serialize without compression
+            StringBufWithRawPointer buf;
+            std::ostream ss(&buf);
+            size_t actual_size = save_raw(ss);
+            // then compress
+            void* raw_pointer = reinterpret_cast<void*>(buf.get_buffer());
+            StringBufWithRawPointer buf_compressed;
+            std::ostream os_compressed(&buf_compressed);
+            size_t compressed_size = utils::compression::compress(raw_pointer, actual_size, os_compressed, mode);
+            if (compressed_size < actual_size) {
+                // finally, write mode plus compressed size plus data to os
+                save_object(os, mode);
+                save_object(os, compressed_size);
+                os.write(buf_compressed.get_buffer(), compressed_size);
+                // total size is compressed size plus mode and a size_t's size
+                return compressed_size + sizeof(CompressionMode) + sizeof(size_t);
+            } else {
+                // if compression is not effective, write mode plus actual size plus data to os
+                save_object(os, CompressionMode::Nil);
+                save_object(os, actual_size);
+                os.write(buf.get_buffer(), actual_size);
+                // total size is actual size plus mode and a size_t's size
+                return actual_size + sizeof(CompressionMode) + sizeof(size_t);
+            
+            }
+        }
+    }
+
+    template <typename R>
+    inline void decompress(std::istream& is, R load_raw) {
+        CompressionMode mode;
+        load_object(is, mode);
+        if (mode == CompressionMode::Nil) {
+            size_t actual_size;
+            load_object(is, actual_size);
+            load_raw(is);
+        } else {
+            size_t compressed_size;
+            load_object(is, compressed_size);
+            std::vector<char> buffer(compressed_size);
+            is.read(buffer.data(), compressed_size);
+            StringBufWithRawPointer buf;
+            std::ostream os(&buf);
+            utils::compression::decompress(buffer.data(), compressed_size, os, mode);
+            std::istream is(&buf);
+            load_raw(is);
+        }
+    }
+
 }}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,8 +42,11 @@ if(TROY_TEST)
         special_prime_for_encryption.cu
 
         multithread.cu
-
     )
+
+    if(TROY_ZSTD)
+        target_sources(troytest PRIVATE serialize_zstd.cu)
+    endif()
 
     target_link_libraries(troytest gtest gtest_main troy)
 

--- a/test/serialize.cu
+++ b/test/serialize.cu
@@ -26,6 +26,36 @@ namespace serialize {
         t = T::load_new(ss, context);
     }
 
+
+    void test_encryptionm_parameters(EncryptionParameters params) {
+        ParmsID id = params.parms_id();
+        reserialize(params);
+        ASSERT_TRUE(params.parms_id() == id);
+    }
+
+    TEST(SerializeTest, BFVEncryptionParameters) {
+        EncryptionParameters params(SchemeType::BFV);
+        params.set_poly_modulus_degree(4096);
+        params.set_coeff_modulus({ 60, 40, 40, 60 });
+        params.set_plain_modulus(1 << 10);
+        test_encryptionm_parameters(params);
+    }
+
+    TEST(SerializeTest, BGVEncryptionParameters) {
+        EncryptionParameters params(SchemeType::BGV);
+        params.set_poly_modulus_degree(4096);
+        params.set_coeff_modulus({ 60, 40, 40, 60 });
+        params.set_plain_modulus(1 << 10);
+        test_encryptionm_parameters(params);
+    }
+
+    TEST(SerializeTest, CKKSEncryptionParameters) {
+        EncryptionParameters params(SchemeType::CKKS);
+        params.set_poly_modulus_degree(4096);
+        params.set_coeff_modulus({ 60, 40, 40, 60 });
+        test_encryptionm_parameters(params);
+    }
+
     void test_plaintext(const GeneralHeContext& context) {
         double scale = context.scale();
         double tolerance = context.tolerance();

--- a/test/serialize_zstd.cu
+++ b/test/serialize_zstd.cu
@@ -2,7 +2,7 @@
 #include "test_adv.h"
 #include <sstream>
 
-namespace serialize {
+namespace serialize_zstd {
 
     using namespace troy;
     using tool::GeneralEncoder;
@@ -13,16 +13,16 @@ namespace serialize {
     template <typename T>
     void reserialize(T& t) {
         stringstream ss;
-        t.save(ss);
-        ASSERT_TRUE(t.serialized_size_upperbound() == ss.str().size());
+        t.save(ss, CompressionMode::Zstd);
+        ASSERT_TRUE(t.serialized_size_upperbound() >= ss.str().size());
         t = T::load_new(ss);
     }
 
     template <typename T>
     void reserialize(T& t, HeContextPointer context) {
         stringstream ss;
-        t.save(ss, context);
-        ASSERT_TRUE(t.serialized_size_upperbound(context) == ss.str().size());
+        t.save(ss, context, CompressionMode::Zstd);
+        ASSERT_TRUE(t.serialized_size_upperbound(context) >= ss.str().size());
         t = T::load_new(ss, context);
     }
 
@@ -36,29 +36,29 @@ namespace serialize {
         ASSERT_TRUE(message.near_equal(decoded, tolerance));
     }
 
-    TEST(SerializeTest, HostBFVPlaintext) {
+    TEST(SerializeZstdTest, HostBFVPlaintext) {
         GeneralHeContext ghe(false, SchemeType::BFV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_plaintext(ghe);
     }
-    TEST(SerializeTest, HostBGVPlaintext) {
+    TEST(SerializeZstdTest, HostBGVPlaintext) {
         GeneralHeContext ghe(false, SchemeType::BGV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_plaintext(ghe);
     }
-    TEST(SerializeTest, HostCKKSPlaintext) {
+    TEST(SerializeZstdTest, HostCKKSPlaintext) {
         GeneralHeContext ghe(false, SchemeType::CKKS, 32, 0, { 60, 60, 60 }, false, 0x123, 10, 1<<16, 1e-2);
         test_plaintext(ghe);
     }
-    TEST(SerializeTest, DeviceBFVPlaintext) {
+    TEST(SerializeZstdTest, DeviceBFVPlaintext) {
         GeneralHeContext ghe(true, SchemeType::BFV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_plaintext(ghe);
         utils::MemoryPool::Destroy();
     }
-    TEST(SerializeTest, DeviceBGVPlaintext) {
+    TEST(SerializeZstdTest, DeviceBGVPlaintext) {
         GeneralHeContext ghe(true, SchemeType::BGV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_plaintext(ghe);
         utils::MemoryPool::Destroy();
     }
-    TEST(SerializeTest, DeviceCKKSPlaintext) {
+    TEST(SerializeZstdTest, DeviceCKKSPlaintext) {
         GeneralHeContext ghe(true, SchemeType::CKKS, 32, 0, { 60, 60, 60 }, false, 0x123, 10, 1<<16, 1e-2);
         test_plaintext(ghe);
         utils::MemoryPool::Destroy();
@@ -96,39 +96,31 @@ namespace serialize {
         decrypted = context.decryptor().decrypt_new(encrypted);
         decoded = context.encoder().decode_simd(decrypted);
         ASSERT_TRUE(message.near_equal(decoded, tolerance));
-
-        // test ciphertext with 3 polys
-        Ciphertext squared = context.evaluator().square_new(encrypted);
-        reserialize(squared, context.context());
-        decrypted = context.decryptor().decrypt_new(squared);
-        decoded = context.encoder().decode_simd(decrypted);
-        GeneralVector truth = context.square(message);
-        ASSERT_TRUE(truth.near_equal(decoded, tolerance));
     }
 
-    TEST(SerializeTest, HostBFVCiphertext) {
+    TEST(SerializeZstdTest, HostBFVCiphertext) {
         GeneralHeContext ghe(false, SchemeType::BFV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_ciphertext(ghe);
     }
-    TEST(SerializeTest, HostBGVCiphertext) {
+    TEST(SerializeZstdTest, HostBGVCiphertext) {
         GeneralHeContext ghe(false, SchemeType::BGV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_ciphertext(ghe);
     }
-    TEST(SerializeTest, HostCKKSCiphertext) {
+    TEST(SerializeZstdTest, HostCKKSCiphertext) {
         GeneralHeContext ghe(false, SchemeType::CKKS, 32, 0, { 60, 60, 60 }, false, 0x123, 10, 1<<16, 1e-2);
         test_ciphertext(ghe);
     }
-    TEST(SerializeTest, DeviceBFVCiphertext) {
+    TEST(SerializeZstdTest, DeviceBFVCiphertext) {
         GeneralHeContext ghe(true, SchemeType::BFV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_ciphertext(ghe);
         utils::MemoryPool::Destroy();
     }
-    TEST(SerializeTest, DeviceBGVCiphertext) {
+    TEST(SerializeZstdTest, DeviceBGVCiphertext) {
         GeneralHeContext ghe(true, SchemeType::BGV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_ciphertext(ghe);
         utils::MemoryPool::Destroy();
     }
-    TEST(SerializeTest, DeviceCKKSCiphertext) {
+    TEST(SerializeZstdTest, DeviceCKKSCiphertext) {
         GeneralHeContext ghe(true, SchemeType::CKKS, 32, 0, { 60, 60, 60 }, false, 0x123, 10, 1<<16, 1e-2);
         test_ciphertext(ghe);
         utils::MemoryPool::Destroy();
@@ -170,29 +162,29 @@ namespace serialize {
         ASSERT_TRUE(message.near_equal(decoded, tolerance));
     }
 
-    TEST(SerializeTest, HostBFVSecretPublicKey) {
+    TEST(SerializeZstdTest, HostBFVSecretPublicKey) {
         GeneralHeContext ghe(false, SchemeType::BFV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_secret_public_key(ghe);
     }
-    TEST(SerializeTest, HostBGVSecretPublicKey) {
+    TEST(SerializeZstdTest, HostBGVSecretPublicKey) {
         GeneralHeContext ghe(false, SchemeType::BGV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_secret_public_key(ghe);
     }
-    TEST(SerializeTest, HostCKKSCSecretPublicKey) {
+    TEST(SerializeZstdTest, HostCKKSCSecretPublicKey) {
         GeneralHeContext ghe(false, SchemeType::CKKS, 32, 0, { 60, 60, 60 }, false, 0x123, 10, 1<<16, 1e-2);
         test_secret_public_key(ghe);
     }
-    TEST(SerializeTest, DeviceBFVSecretPublicKey) {
+    TEST(SerializeZstdTest, DeviceBFVSecretPublicKey) {
         GeneralHeContext ghe(true, SchemeType::BFV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_secret_public_key(ghe);
         utils::MemoryPool::Destroy();
     }
-    TEST(SerializeTest, DeviceBGVSecretPublicKey) {
+    TEST(SerializeZstdTest, DeviceBGVSecretPublicKey) {
         GeneralHeContext ghe(true, SchemeType::BGV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_secret_public_key(ghe);
         utils::MemoryPool::Destroy();
     }
-    TEST(SerializeTest, DeviceCKKSSecretPublicKey) {
+    TEST(SerializeZstdTest, DeviceCKKSSecretPublicKey) {
         GeneralHeContext ghe(true, SchemeType::CKKS, 32, 0, { 60, 60, 60 }, false, 0x123, 10, 1<<16, 1e-2);
         test_secret_public_key(ghe);
         utils::MemoryPool::Destroy();
@@ -299,29 +291,29 @@ namespace serialize {
         }
     }
 
-    TEST(SerializeTest, HostBFVKSwitchKeys) {
+    TEST(SerializeZstdTest, HostBFVKSwitchKeys) {
         GeneralHeContext ghe(false, SchemeType::BFV, 32, 20, { 60, 40, 40, 60 }, true, 0x123, 0);
         test_kswitch_keys(ghe);
     }
-    TEST(SerializeTest, HostBGVKSwitchKeys) {
+    TEST(SerializeZstdTest, HostBGVKSwitchKeys) {
         GeneralHeContext ghe(false, SchemeType::BGV, 32, 20, { 60, 40, 40, 60 }, true, 0x123, 0);
         test_kswitch_keys(ghe);
     }
-    TEST(SerializeTest, HostCKKSKSwitchKeys) {
+    TEST(SerializeZstdTest, HostCKKSKSwitchKeys) {
         GeneralHeContext ghe(false, SchemeType::CKKS, 32, 0, { 60, 40, 40, 60 }, true, 0x123, 10, 1ull<<20, 1e-2);
         test_kswitch_keys(ghe);
     }
-    TEST(SerializeTest, DeviceBFVKSwitchKeys) {
+    TEST(SerializeZstdTest, DeviceBFVKSwitchKeys) {
         GeneralHeContext ghe(true, SchemeType::BFV, 32, 20, { 60, 40, 40, 60 }, true, 0x123, 0);
         test_kswitch_keys(ghe);
         utils::MemoryPool::Destroy();
     }
-    TEST(SerializeTest, DeviceBGVKSwitchKeys) {
+    TEST(SerializeZstdTest, DeviceBGVKSwitchKeys) {
         GeneralHeContext ghe(true, SchemeType::BGV, 32, 20, { 60, 40, 40, 60 }, true, 0x123, 0);
         test_kswitch_keys(ghe);
         utils::MemoryPool::Destroy();
     }
-    TEST(SerializeTest, DeviceCKKSKSwitchKeys) {
+    TEST(SerializeZstdTest, DeviceCKKSKSwitchKeys) {
         GeneralHeContext ghe(true, SchemeType::CKKS, 32, 0, { 60, 40, 40, 60 }, true, 0x123, 10, 1ull<<20, 1e-2);
         test_kswitch_keys(ghe);
         utils::MemoryPool::Destroy();
@@ -329,8 +321,8 @@ namespace serialize {
     
     void reserialize_terms(Ciphertext& t, HeContextPointer context, const std::vector<size_t>& terms) {
         stringstream ss;
-        t.save_terms(ss, context, terms);
-        ASSERT_TRUE(t.serialized_terms_size_upperbound(context, terms) == ss.str().size());
+        t.save_terms(ss, context, terms, MemoryPool::GlobalPool(), CompressionMode::Zstd);
+        ASSERT_TRUE(t.serialized_terms_size_upperbound(context, terms) >= ss.str().size());
         t = Ciphertext::load_terms_new(ss, context, terms);
     }
 
@@ -380,29 +372,29 @@ namespace serialize {
 
     }
 
-    TEST(SerializeTest, HostBFVCiphertextTerms) {
+    TEST(SerializeZstdTest, HostBFVCiphertextTerms) {
         GeneralHeContext ghe(false, SchemeType::BFV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_ciphertext_terms(ghe);
     }
-    TEST(SerializeTest, HostBGVCiphertextTerms) {
+    TEST(SerializeZstdTest, HostBGVCiphertextTerms) {
         GeneralHeContext ghe(false, SchemeType::BGV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_ciphertext_terms(ghe);
     }
-    TEST(SerializeTest, HostCKKSCiphertextTerms) {
+    TEST(SerializeZstdTest, HostCKKSCiphertextTerms) {
         GeneralHeContext ghe(false, SchemeType::CKKS, 32, 0, { 60, 60, 60 }, false, 0x123, 10, 1<<16, 1e-2);
         test_ciphertext_terms(ghe);
     }
-    TEST(SerializeTest, DeviceBFVCiphertextTerms) {
+    TEST(SerializeZstdTest, DeviceBFVCiphertextTerms) {
         GeneralHeContext ghe(true, SchemeType::BFV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_ciphertext_terms(ghe);
         utils::MemoryPool::Destroy();
     }
-    TEST(SerializeTest, DeviceBGVCiphertextTerms) {
+    TEST(SerializeZstdTest, DeviceBGVCiphertextTerms) {
         GeneralHeContext ghe(true, SchemeType::BGV, 32, 20, { 40, 40, 40 }, false, 0x123, 0);
         test_ciphertext_terms(ghe);
         utils::MemoryPool::Destroy();
     }
-    TEST(SerializeTest, DeviceCKKSCiphertextTerms) {
+    TEST(SerializeZstdTest, DeviceCKKSCiphertextTerms) {
         GeneralHeContext ghe(true, SchemeType::CKKS, 32, 0, { 60, 60, 60 }, false, 0x123, 10, 1<<16, 1e-2);
         test_ciphertext_terms(ghe);
         utils::MemoryPool::Destroy();


### PR DESCRIPTION
Add zstd compression option when serializing.
- Submodule of zstd repository.
- Option defaultly enabled in CMake.
- User need to explicitly call with compression_mode = CompressionMode::Zstd to enable this when serializing anything.
- Add serialization support for encryption parameters.