### PR TITLE
Fix "[MemoryPool::get] The singleton has been destroyed."

### DIFF
--- a/src/utils/memory_pool.h
+++ b/src/utils/memory_pool.h
@@ -61,18 +61,15 @@ namespace troy {namespace utils {
         struct Impl;
         std::shared_ptr<Impl> impl_;
         inline static void ensure_global_pool() {
-
             std::unique_lock<std::mutex> lock(global_pool_mutex);
             if (global_pool == nullptr) {
-                if (global_pool == nullptr) {
-                    int count = device_count();
-                    has_device = count > 0;
-                    if (!has_device) {
-                        return;
-                    }
-                    global_pool = std::make_shared<MemoryPool>(0);
-                    global_pool->is_global_pool = true;
+                int count = device_count();
+                has_device = count > 0;
+                if (!has_device) {
+                    return;
                 }
+                global_pool = std::make_shared<MemoryPool>(0);
+                global_pool->is_global_pool = true;
             }
         }
         inline static void runtime_error(const char* prompt, cudaError_t status) {

--- a/src/utils/memory_pool.h
+++ b/src/utils/memory_pool.h
@@ -61,19 +61,18 @@ namespace troy {namespace utils {
         struct Impl;
         std::shared_ptr<Impl> impl_;
         inline static void ensure_global_pool() {
-            if (!established) {
-                std::unique_lock lock(global_pool_mutex);
-                if (global_pool != nullptr) {
-                    return;
+
+            std::unique_lock<std::mutex> lock(global_pool_mutex);
+            if (global_pool == nullptr) {
+                if (global_pool == nullptr) {
+                    int count = device_count();
+                    has_device = count > 0;
+                    if (!has_device) {
+                        return;
+                    }
+                    global_pool = std::make_shared<MemoryPool>(0);
+                    global_pool->is_global_pool = true;
                 }
-                int count = device_count();
-                has_device = count > 0;
-                established = true;
-                if (!has_device) {
-                    return;
-                }
-                global_pool = std::make_shared<MemoryPool>(0);
-                global_pool->is_global_pool = true;
             }
         }
         inline static void runtime_error(const char* prompt, cudaError_t status) {

--- a/src/utils/memory_pool_safe.in
+++ b/src/utils/memory_pool_safe.in
@@ -13,7 +13,7 @@ namespace troy::utils {
     struct MemoryPool::Impl {
         static const int PRESERVED_MEMORY_BYTES = 1024 * 1024 * 32;
         std::shared_mutex mutex;
-
+        
         // key-value pairs are (allocated memory size, (pointer address, last used thread id))
         std::multimap<size_t, std::pair<void*, std::thread::id>> unused;
 
@@ -53,7 +53,7 @@ namespace troy::utils {
     }
     
     void* MemoryPool::try_allocate(size_t required) {
-        std::unique_lock lock(impl_->mutex);
+        std::unique_lock<std::shared_mutex> lock(impl_->mutex);
         size_t free, total;
         set_device();
         cudaError_t status = cudaMemGetInfo(&free, &total);
@@ -91,7 +91,7 @@ namespace troy::utils {
         if (impl_->destroyed) {
 
             // the ptr given back should be in the zombie set
-            std::unique_lock lock(impl_->mutex);
+            std::unique_lock<std::shared_mutex> lock(impl_->mutex);
             auto iterator = impl_->zombie.find(ptr);
             if (iterator == impl_->zombie.end()) {
                 throw std::runtime_error("[MemoryPool(safe)::release] The pointer is not in the zombie set.");
@@ -101,7 +101,7 @@ namespace troy::utils {
 
         }
 
-        std::unique_lock lock(impl_->mutex);
+        std::unique_lock<std::shared_mutex> lock(impl_->mutex);
         auto iterator = impl_->allocated.find(ptr);
         if (iterator == impl_->allocated.end()) {
             throw std::runtime_error("[MemoryPool(safe)::release] The pointer is not in the allocated set.");
@@ -117,7 +117,7 @@ namespace troy::utils {
         if (impl_->destroyed) {
             throw std::runtime_error("[MemoryPool(safe)::get] The singleton has been destroyed.");
         }
-        std::unique_lock lock(impl_->mutex);
+        std::unique_lock<std::shared_mutex> lock(impl_->mutex);
         auto iterator = impl_->unused.lower_bound(required);
         if (iterator == impl_->unused.end() || iterator->first >= required * 2) {
             lock.unlock();
@@ -140,7 +140,7 @@ namespace troy::utils {
     }
 
     void MemoryPool::release_unused() {
-        std::unique_lock lock(impl_->mutex);
+        std::unique_lock<std::shared_mutex> lock(impl_->mutex);
         for (auto it = impl_->unused.begin(); it != impl_->unused.end();) {
             set_device();
             cudaError_t status = cudaFree(it->second.first);
@@ -158,7 +158,7 @@ namespace troy::utils {
     }
 
     void MemoryPool::destroy() {
-        std::unique_lock lock(impl_->mutex);
+        std::unique_lock<std::shared_mutex> lock(impl_->mutex);
         // first release all unused
         for (auto it = impl_->unused.begin(); it != impl_->unused.end();) {
             set_device();
@@ -188,6 +188,11 @@ namespace troy::utils {
         impl_->unused.clear();
         impl_->total_allocated = 0;
         impl_->destroyed = true;
+        established = false;
+
+        if (is_global_pool) {
+            global_pool = nullptr;
+        }
     }
 
 }

--- a/src/utils/memory_pool_safe.in
+++ b/src/utils/memory_pool_safe.in
@@ -13,7 +13,7 @@ namespace troy::utils {
     struct MemoryPool::Impl {
         static const int PRESERVED_MEMORY_BYTES = 1024 * 1024 * 32;
         std::shared_mutex mutex;
-        
+
         // key-value pairs are (allocated memory size, (pointer address, last used thread id))
         std::multimap<size_t, std::pair<void*, std::thread::id>> unused;
 

--- a/src/utils/memory_pool_safe.in
+++ b/src/utils/memory_pool_safe.in
@@ -53,7 +53,7 @@ namespace troy::utils {
     }
     
     void* MemoryPool::try_allocate(size_t required) {
-        std::unique_lock<std::shared_mutex> lock(impl_->mutex);
+        std::unique_lock lock(impl_->mutex);
         size_t free, total;
         set_device();
         cudaError_t status = cudaMemGetInfo(&free, &total);
@@ -91,7 +91,7 @@ namespace troy::utils {
         if (impl_->destroyed) {
 
             // the ptr given back should be in the zombie set
-            std::unique_lock<std::shared_mutex> lock(impl_->mutex);
+            std::unique_lock lock(impl_->mutex);
             auto iterator = impl_->zombie.find(ptr);
             if (iterator == impl_->zombie.end()) {
                 throw std::runtime_error("[MemoryPool(safe)::release] The pointer is not in the zombie set.");
@@ -101,7 +101,7 @@ namespace troy::utils {
 
         }
 
-        std::unique_lock<std::shared_mutex> lock(impl_->mutex);
+        std::unique_lock lock(impl_->mutex);
         auto iterator = impl_->allocated.find(ptr);
         if (iterator == impl_->allocated.end()) {
             throw std::runtime_error("[MemoryPool(safe)::release] The pointer is not in the allocated set.");
@@ -117,7 +117,7 @@ namespace troy::utils {
         if (impl_->destroyed) {
             throw std::runtime_error("[MemoryPool(safe)::get] The singleton has been destroyed.");
         }
-        std::unique_lock<std::shared_mutex> lock(impl_->mutex);
+        std::unique_lock lock(impl_->mutex);
         auto iterator = impl_->unused.lower_bound(required);
         if (iterator == impl_->unused.end() || iterator->first >= required * 2) {
             lock.unlock();
@@ -140,7 +140,7 @@ namespace troy::utils {
     }
 
     void MemoryPool::release_unused() {
-        std::unique_lock<std::shared_mutex> lock(impl_->mutex);
+        std::unique_lock lock(impl_->mutex);
         for (auto it = impl_->unused.begin(); it != impl_->unused.end();) {
             set_device();
             cudaError_t status = cudaFree(it->second.first);
@@ -158,7 +158,7 @@ namespace troy::utils {
     }
 
     void MemoryPool::destroy() {
-        std::unique_lock<std::shared_mutex> lock(impl_->mutex);
+        std::unique_lock lock(impl_->mutex);
         // first release all unused
         for (auto it = impl_->unused.begin(); it != impl_->unused.end();) {
             set_device();

--- a/src/utils/memory_pool_unsafe.in
+++ b/src/utils/memory_pool_unsafe.in
@@ -23,7 +23,7 @@ namespace troy::utils {
         cudaDeviceProp props;
         cudaError_t status = cudaGetDeviceProperties(&props, device_index);
         if (status != cudaSuccess) {
-            runtime_error("[MemoryPool::MemoryPool] cudaGetDeviceProperties failed.", status);
+            runtime_error("[MemoryPool(unsafe)::MemoryPool] cudaGetDeviceProperties failed.", status);
         }
     }
 

--- a/test/bench/ntt.cu
+++ b/test/bench/ntt.cu
@@ -43,18 +43,18 @@ int main(int argc, char** argv) {
 
     constexpr size_t warm_up = 10;
     for (size_t i = 0; i < warm_up; i++) {
-        troy::utils::ntt(a.reference(), n, table.as_const_pointer());
-        troy::utils::intt(a.reference(), n, table.as_const_pointer());
+        troy::utils::ntt_inplace(a.reference(), n, table.as_const_pointer());
+        troy::utils::intt_inplace(a.reference(), n, table.as_const_pointer());
     }
 
     for (size_t i = 0; i < repeat; i++) {
     
         timer.tick(timer_ntt);
-        troy::utils::ntt(a.reference(), n, table.as_const_pointer());
+        troy::utils::ntt_inplace(a.reference(), n, table.as_const_pointer());
         timer.tock(timer_ntt);
 
         timer.tick(timer_intt);
-        troy::utils::intt(a.reference(), n, table.as_const_pointer());
+        troy::utils::intt_inplace(a.reference(), n, table.as_const_pointer());
         timer.tock(timer_intt);
 
     }


### PR DESCRIPTION
`MemoryPool::GlobalPool()` relies on the `established`  to determine the status of the current global memory pool. However, ` MemoryPool::destroy()` does not update the `established`  after the pool is destroyed. Thus, calling `MemoryPool::destroy()`, invoking `MemoryPool::GlobalPool()` again results in the error message: "[MemoryPool::get] The singleton has been destroyed.".

Here is the poc:

```cpp
#include "troy/troy.h"

using namespace troy;

int main() {
    
    utils::Array<Modulus> modulus(3, false, nullptr);
    modulus[0] = Modulus(2);
    modulus[1] = Modulus(10);
    modulus[2] = Modulus(2305843009211596801ULL);
    utils::Array<Modulus> device_modulus = modulus.to_device(MemoryPool::GlobalPool());
    utils::Array<bool> r(16, true, MemoryPool::GlobalPool()); 
    utils::set_device(r.device_index());
    utils::stream_sync();
    utils::Array<bool> h = r.to_host();
    cudaDeviceSynchronize();
    MemoryPool::Destroy();

    utils::Array<Modulus> device_modulus_2 = modulus.to_device(MemoryPool::GlobalPool());
    utils::Array<bool> r_2(16, true, MemoryPool::GlobalPool()); 
    utils::set_device(r_2.device_index());
    utils::stream_sync();
    utils::Array<bool> h_2 = r_2.to_host();
    cudaDeviceSynchronize();
    MemoryPool::Destroy();

    
    return 0;
}
```